### PR TITLE
Update to IOU score multi

### DIFF
--- a/eval_functions.py
+++ b/eval_functions.py
@@ -110,7 +110,12 @@ def _iou_score(vrA, vrB, use_G=False):
     return iou
 
 def iou_score_multi(vrAs, vrBs, use_G=False):
-    return _score_multi(vrAs, vrBs, _iou_score, use_G=use_G)
+    combine_fn = lambda x, y: (np.mean(x) + np.mean(y)) / 2
+    return _score_multi(vrAs,
+                        vrBs,
+                        _iou_score,
+                        combine_fn=combine_fn,
+                        use_G=use_G)
 
 def _iou_f1(vrA, vrB):
     return np.round(_iou_score(vrA, vrB))


### PR DESCRIPTION
My reading of _\Delta(A, B)_ in the paper for "bounding boxes and keypoints" is that the means of _A_ and _B_ should be taken before doing the addition. If correct, I believe this is different from what is produced in the implementation. Consider a case where _A_ has three boxes and _B_ has four; max distances may be as follows:

```
In [1]: scoresA = [0.6, 0.4, 0.2]
In [2]: scoresB = a + [0.1]
```

which would be the lists produced by lines [73 and 74](https://github.com/Praznat/annotationmodeling/blob/be0de44e51792c3818ae28f9bd62a32257d48fe2/eval_functions.py#L73-L74). I feel this case is plausible because IOUs symmetry means one set must always be a subset of the other. Line [75](https://github.com/Praznat/annotationmodeling/blob/be0de44e51792c3818ae28f9bd62a32257d48fe2/eval_functions.py#L75) would then go on to produce:

```
In [3]: np.mean(scoresA + scoresB)
Out[3]: 0.35714285714285715
```
however, shouldn't it be:

```
In [4]: (np.mean(scoresA) + np.mean(scoresB)) / 2
Out[4]: 0.3625
```

This pull request suggests that change by populating the combine function parameter in the multi-scoring function.